### PR TITLE
Fix object datum on player and object views

### DIFF
--- a/lib/game/src/halo3/base/type.h
+++ b/lib/game/src/halo3/base/type.h
@@ -15,14 +15,19 @@ typedef unsigned int StringID;
 
 template<typename T>
 struct entity_manager_t {
-    char m_name[0x20];  // 0x0
-    __int32 m_max;      // 0x20
-    __int32 m_sizeof;   // 0x24
-    __int32 m_un1[5];   // 0x28
-    __int32 m_capacity; // 0x3C
-    __int32 m_size;     // 0x40
-    __int32 m_un2;      // 0x44
-    __int64 m_data;     // 0x48
+    char m_name[0x20];             // 0x0
+    __int32 m_max;                 // 0x20
+    __int32 m_sizeof;              // 0x24
+    __int32 m_un1;                 // 0x28
+    __int32 m_signature;           // 0x2C
+    __int32 m_un2[2];              // 0x30
+    unsigned __int16 m_next_index; // 0x3A
+    __int16 m_un3;                 // 0x3A
+    __int32 m_capacity;            // 0x3C
+    __int32 m_size;                // 0x40
+    unsigned __int16 m_next_id;    // 0x44
+    __int16 m_un4;                 // 0x46
+    __int64 m_data;                // 0x48
 
     inline bool isValid(__int16 index) const { return index >= 0 && index < m_size && index < m_max; }
     inline T* get(__int16 index) const { return (T*)(m_data + (__int64)m_sizeof * (__int16)index); }

--- a/lib/game/src/halo3/game/players.h
+++ b/lib/game/src/halo3/game/players.h
@@ -26,7 +26,7 @@ struct players_definition {
     __int16 machine_controller_index1;
     char cluster_reference;
     char padding[3];
-    INDEX unit_index; // 40
+    Datum unit_datum; // 40
     INDEX restore_INDEX; // 0x2C
     __int8 v1[0x1C];
     Vector3 position;// 0x4C

--- a/lib/game/src/halo3/objects/objects.h
+++ b/lib/game/src/halo3/objects/objects.h
@@ -20,7 +20,7 @@ struct objects_definition {
         _object_has_override_bit = 0x2000000,
     };
 
-    Datum datum;//0x0
+    INDEX tag_index; // 0x0
     eObjectFlags object_flags; //0x4
     int v0;
     INDEX next_object_index;//0xC
@@ -70,7 +70,9 @@ struct objects_definition {
 };
 
 struct object_definition {
-    __int64 v0;
-    __int64 v1;
+    unsigned __int16 id;
+    __int32 unknown_1;
+    __int32 unknown_2;
+    __int32 size;
     objects_definition* address;
 };

--- a/src/render/imgui/game/halo3/context_object.cpp
+++ b/src/render/imgui/game/halo3/context_object.cpp
@@ -42,7 +42,7 @@ void CHalo3Context::context_object() {
                 for (Index i = 0; p_tag_names && i < mng->m_capacity; ++i) {
                     auto object = mng->get(i)->address;
                     if (object == nullptr || !bFilter[object->type]) continue;
-                    auto tag_name = p_tag_names->get(object->datum);
+                    auto tag_name = p_tag_names->get(object->tag_index);
                     if (tag_name == nullptr) continue;
                     tag_name = strrchr(tag_name, '\\');
                     if (tag_name == nullptr) continue;
@@ -73,7 +73,7 @@ void CHalo3Context::context_object() {
 static void print_object(int index) {
     const char* object_format = R"(
 Object:
-    Datum: %X
+    Object Datum: %X
     Parent Object: %X
     Child Object: %X
     Position: %.2f %.2f %.2f
@@ -95,7 +95,13 @@ Unit:
 
     if (mng == nullptr || index < 0 || index > mng->m_capacity) return;
 
-    auto p_object = mng->get(index)->address;
+
+
+    auto object_entry = mng->get(index);
+    auto object_datum = (((unsigned __int32)object_entry->id) << 16) | ((unsigned __int32)index);
+
+    auto p_object = object_entry->address;
+
     units_definition* p_unit = nullptr;
 
     if (p_object == nullptr) return;
@@ -108,7 +114,7 @@ Unit:
     if (p_object->isUnit()) p_unit = (units_definition*)p_object;
 
     sprintf(buffer, object_format,
-            p_object->datum, p_object->parent_object_index, p_object->next_object_index,
+            object_datum, p_object->parent_object_index, p_object->next_object_index,
             p_object->position.x, p_object->position.y, p_object->position.z,
             eObjectTypeName[p_object->type]
     );

--- a/src/render/imgui/game/halo3/context_player.cpp
+++ b/src/render/imgui/game/halo3/context_player.cpp
@@ -6,7 +6,7 @@ static bool show_context = false;
 static const char* format = R"(
 Player %d
     Name: %s
-    INDEX: %X
+    Object Datum: %X
     Position: %.2f %.2f %.2f
     Team: %d
 )";
@@ -33,8 +33,6 @@ void CHalo3Context::context_player() {
 
         ImGui::Checkbox("Disable Action", &p_action->disable_input);
 
-        ImGui::SameLine();
-
         for (int i = 0; i < p_players->m_capacity; ++i) {
             auto p_player = p_players->get(i);
 
@@ -42,7 +40,7 @@ void CHalo3Context::context_player() {
 
             std::wcstombs(player_name, p_player->configuration.client.player_name, sizeof(player_name));
             sprintf_s(buffer, format,
-                      i, player_name, p_player->unit_index,
+                      i, player_name, p_player->unit_datum,
                       p_player->position.x, p_player->position.y, p_player->position.z,
                       p_player->configuration.host.player_team
             );


### PR DESCRIPTION
This change allows the user to extract the current object datum for any object in the object table.

I was a bit confused when reading the object table as it seems it uses the tag index, rather than the object datum. This updates the object view to show the proper datum for the object. For the player view, it renames it from INDEX to Object Datum. 
